### PR TITLE
fix(object) allow for non-object defaults on objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
 'use strict'
 
 const prepareChildren = (root, value) => {
-  if (root.schema.type === 'object') {
+  if (root.schema.type === 'object' && root.schema.$_terms.keys) {
     value = value || {}
-    if (root.schema.$_terms.keys) {
-      for (const child of root.schema.$_terms.keys) {
-        value[child.key] = prepareChildren(child, value[child.key])
-      }
+    for (const child of root.schema.$_terms.keys) {
+      value[child.key] = prepareChildren(child, value[child.key])
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -3,8 +3,10 @@
 const prepareChildren = (root, value) => {
   if (root.schema.type === 'object') {
     value = value || {}
-    for (const child of root.schema.$_terms.keys) {
-      value[child.key] = prepareChildren(child, value[child.key])
+    if (root.schema.$_terms.keys) {
+      for (const child of root.schema.$_terms.keys) {
+        value[child.key] = prepareChildren(child, value[child.key])
+      }
     }
   }
 

--- a/test/main.js
+++ b/test/main.js
@@ -53,6 +53,6 @@ describe('.env', () => {
       nested: Joi.object().default(null)
     })
     const config = schema.validate({})
-    expect(config.nested).to.not.exist()
+    expect(config.value.nested).to.equal(null)
   })
 })

--- a/test/main.js
+++ b/test/main.js
@@ -47,4 +47,12 @@ describe('.env', () => {
     const config = schema.validate({})
     expect(config.value).to.equal({ myKey: undefined })
   })
+
+  it('validates object w/ default null', () => {
+    const schema = Joi.object({
+      nested: Joi.object().default(null)
+    })
+    const config = schema.validate({})
+    expect(config.nested).to.not.exist()
+  })
 })


### PR DESCRIPTION
# What / Why
This needs to work:
```javascript
    const schema = Joi.object({
      nested: Joi.object().default(null)
   })
```